### PR TITLE
use NEXT_PUBLIC_VERCEL_URL 

### DIFF
--- a/frontend/app/utils/constants.tsx
+++ b/frontend/app/utils/constants.tsx
@@ -1,4 +1,4 @@
-const apiBasePath = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
+const apiBasePath = process.env.NEXT_PUBLIC_VERCEL_URL
+  ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
   : `http://localhost:3000`;
 export const apiBaseUrl = `${apiBasePath}/api`;


### PR DESCRIPTION
use NEXT_PUBLIC_VERCEL_URL instead of VERCEL_URL to make vercel deployment working.

before this change, vercel deployment will try to connect to localhost. Resulting an error when try to send message.

![screenshot-20240308-180255](https://github.com/langchain-ai/chat-langchainjs/assets/132834/229bb307-4e51-4573-aa62-88ada6d0be48)
