### PR TITLE
fix yarn build --filter=backend operation not permitted error

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,7 @@
     "lint:dpdm": "dpdm --exit-code circular:1 --no-warning --no-tree src/*.ts src/**/*.ts",
     "lint": "yarn lint:eslint && yarn lint:dpdm",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:dpdm",
-    "clean": "rimraf .turbo/ dist/",
+    "clean": "rimraf dist/",
     "format": "prettier --config .prettierrc --write \"src\"",
     "format:check": "prettier --config .prettierrc --check \"src\""
   },


### PR DESCRIPTION
when run 'yarn build --filter=backend' faced this error:
 WARNING  stale pid file at "C:\\Users\\Administrator\\AppData\\Local\\Temp\\turbod\\efdb3a4d8a8a6c6c\\turbod.pid"
• Packages in scope: backend
• Running build in 1 packages
• Remote caching disabled
backend:build: cache miss, executing b4335d3b359281be
backend:build: [Error: EPERM: operation not permitted, unlink 'E:\work_future\AI-js\chat-langchainjs\backend\.turbo\turbo-build.log'] {
backend:build:   errno: -4048,
backend:build:   code: 'EPERM',
backend:build:   syscall: 'unlink',
backend:build:   path: 'E:\\work_future\\AI-js\\chat-langchainjs\\backend\\.turbo\\turbo-build.log'
backend:build: }
backend:build: ERROR: command finished with error: command (E:\work_future\AI-js\chat-langchainjs\backend) C:\Users\Administrator\AppData\Local\Temp\xfs-f7e01033\yarn.cmd run build exited (1)
backend#build: command (E:\work_future\AI-js\chat-langchainjs\backend) C:\Users\Administrator\AppData\Local\Temp\xfs-f7e01033\yarn.cmd run build exited (1)

 Tasks:    0 successful, 1 total
Cached:    0 cached, 1 total
  Time:    2.652s
Failed:    backend#build

 ERROR  run failed: command  exited (1)