### PR TITLE
Update "LangChain" to "LangChain.js" for easier differentiation

### DIFF
--- a/frontend/app/components/ChatWindow.tsx
+++ b/frontend/app/components/ChatWindow.tsx
@@ -215,7 +215,7 @@ export function ChatWindow(props: { conversationId: string }) {
           mb={1}
           color={"white"}
         >
-          Chat LangChain 🦜🔗
+          Chat LangChain.js 🦜🔗
         </Heading>
         {messages.length > 0 ? (
           <Heading fontSize="md" fontWeight={"normal"} mb={1} color={"white"}>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -5,8 +5,8 @@ import { Inter } from "next/font/google";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Chat LangChain",
-  description: "Chatbot for LangChain",
+  title: "Chat LangChain.js",
+  description: "Chatbot for LangChain.js",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Currently the title of the chat page is "Chat LangChain", which is identical to the title of the page for the [Python version](https://chat.langchain.com/), making it difficult to tell which tab is which at a glance if you have both the JS and Python chats open at the same time.

This PR simply changes the title of the page as well as the header to be LangChain.js for easier differentiation at a glance.